### PR TITLE
fix: app selector type on lang selectors

### DIFF
--- a/src/redux/lang/lang.selectors.ts
+++ b/src/redux/lang/lang.selectors.ts
@@ -3,12 +3,14 @@ import { Selector } from "react-redux";
 
 import { LangCode } from "@src/locales";
 
+import store from "../redux.store";
+
 import { LangState } from "./lang.slice";
 
-export interface LangSelectors<T> {
-  selectCode: Selector<T, LangCode>;
+export interface LangSelectors {
+  selectCode: Selector<ReturnType<typeof store.getState>, LangCode>;
 }
 
-export const langSelectors = <T>(slicer: Selector<T, LangState>): LangSelectors<T> => ({
+export const langSelectors = (slicer: Selector<ReturnType<typeof store.getState>, LangState>): LangSelectors => ({
   selectCode: createSelector(slicer, (state) => state.code)
 });


### PR DESCRIPTION
Motivation:

Type incompatibility between the lang selectors and the redux state.

Modifications:

 * use the state return by the store as AppState

Result:

Fixed lang selectors in redux tool kit.